### PR TITLE
Enable 1305,1720,1721,1806 Rules (#1604)

### DIFF
--- a/lib/PuppeteerSharp.ruleset
+++ b/lib/PuppeteerSharp.ruleset
@@ -70,11 +70,11 @@
     <Rule Id="CA1064" Action="Error" /> <!-- Error CA1064: Exceptions should be public (CA1064)-->
     <Rule Id="CA1001" Action="None" /> <!-- Error CA1001: A class owns a disposable -->
     <Rule Id="CA1304" Action="Error" /> <!-- Error CA1304: The behavior of 'string.ToLower()' could vary based on the current user's locale settings. Replace this call in 'JSHandle.ToString()' with a call to 'string.ToLower(CultureInfo)'. (CA1304) -->
-    <Rule Id="CA1305" Action="None" /> <!-- String.Format with culture-->
-    <Rule Id="CA1720" Action="None" /> <!-- Error SA1720: Name contains type-->
-    <Rule Id="CA1721" Action="None" /> <!-- Error CA1721: The property name 'DefaultArgs' is confusing given the existence of method 'GetDefaultArgs'. Rename or remove one of these members. (CA1721)-->
+    <Rule Id="CA1305" Action="Error" /> <!-- String.Format with culture-->
+    <Rule Id="CA1720" Action="Error" /> <!-- Error SA1720: Name contains type-->
+    <Rule Id="CA1721" Action="Error" /> <!-- Error CA1721: The property name 'DefaultArgs' is confusing given the existence of method 'GetDefaultArgs'. Rename or remove one of these members. (CA1721)-->
     <Rule Id="CA1724" Action="None" /> <!-- Error CA1724: The type name Extensions conflicts in whole or in part with the namespace name 'Microsoft.Extensions'. Change either name to eliminate the conflict. (CA1724) -->
-    <Rule Id="CA1806" Action="None" /> <!-- Error CA1806: DownloadAsync calls Chmod but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method. (CA1806)-->
+    <Rule Id="CA1806" Action="Error" /> <!-- Error CA1806: DownloadAsync calls Chmod but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method. (CA1806)-->
     <Rule Id="CA1816" Action="Error" /> <!-- Error CA1816: Change Connection.Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it. (CA1816) -->
     <Rule Id="CA2000" Action="Error" /> <!-- Error CA2000: Call System.IDisposable.Dispose on object created by 'new Process()' before all references to it are out of scope. (CA2000) -->
     <Rule Id="CA2008" Action="None" /> <!-- Error ca2008: Pass TaskScheduler-->

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -220,7 +221,11 @@ namespace PuppeteerSharp
 
             if (revisionInfo != null && GetCurrentPlatform() == Platform.Linux)
             {
-                LinuxSysCall.Chmod(revisionInfo.ExecutablePath, LinuxSysCall.ExecutableFilePermissions);
+                int code = LinuxSysCall.Chmod(revisionInfo.ExecutablePath, LinuxSysCall.ExecutableFilePermissions);
+                if (code == -1)
+                {
+                    throw new Exception("Chmod operation failed");
+                }
             }
 
             return revisionInfo;
@@ -318,9 +323,7 @@ namespace PuppeteerSharp
             {
                 return 0;
             }
-
-            int.TryParse(splits[1], out int revision);
-            return revision;
+            return int.Parse(splits[1], CultureInfo.CurrentCulture);
         }
 
         private static string GetArchiveName(Platform platform, int revision)
@@ -340,7 +343,7 @@ namespace PuppeteerSharp
         }
 
         private static string GetDownloadURL(Platform platform, string host, int revision)
-            => string.Format(_downloadUrls[platform], host, revision, GetArchiveName(platform, revision));
+            => string.Format(CultureInfo.CurrentCulture, _downloadUrls[platform], host, revision, GetArchiveName(platform, revision));
 
         #endregion
     }

--- a/lib/PuppeteerSharp/Helpers/AsyncDictionaryHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/AsyncDictionaryHelper.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace PuppeteerSharp.Helpers
@@ -29,7 +30,7 @@ namespace PuppeteerSharp.Helpers
             }
 
             return await tcs.Task.WithTimeout(new Action(() =>
-                throw new PuppeteerException(string.Format(_timeoutMessage, key))), 1000).ConfigureAwait(false);
+                throw new PuppeteerException(string.Format(CultureInfo.CurrentCulture, _timeoutMessage, key))), 1000).ConfigureAwait(false);
         }
 
         internal async Task<TValue> TryGetItemAsync(TKey key)

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;
 using PuppeteerSharp.Transport;

--- a/lib/PuppeteerSharp/Messaging/RemoteObjectType.cs
+++ b/lib/PuppeteerSharp/Messaging/RemoteObjectType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Messaging
@@ -16,7 +16,9 @@ namespace PuppeteerSharp.Messaging
         /// <summary>
         /// Object.
         /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name
         Object,
+#pragma warning restore CA1720 // Identifier contains type name
         /// <summary>
         /// Function.
         /// </summary>
@@ -28,7 +30,9 @@ namespace PuppeteerSharp.Messaging
         /// <summary>
         /// String.
         /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name
         String,
+#pragma warning restore CA1720 // Identifier contains type name
         /// <summary>
         /// Number.
         /// </summary>

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -2046,7 +2046,7 @@ namespace PuppeteerSharp
             decimal pixels;
             if (parameter is decimal || parameter is int)
             {
-                pixels = Convert.ToDecimal(parameter);
+                pixels = Convert.ToDecimal(parameter, CultureInfo.CurrentCulture);
             }
             else
             {

--- a/lib/PuppeteerSharp/Puppeteer.cs
+++ b/lib/PuppeteerSharp/Puppeteer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Mobile;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -24,7 +24,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// The default flags that Chromium will be launched with.
         /// </summary>
-        public static string[] DefaultArgs => ChromiumLauncher.DefaultArgs;
+        internal static string[] DefaultArgs => ChromiumLauncher.DefaultArgs;
 
         /// <summary>
         /// A path where Puppeteer expects to find bundled browser. It might not exist there if the downloader was not used.

--- a/lib/PuppeteerSharp/Request.cs
+++ b/lib/PuppeteerSharp/Request.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -246,7 +247,7 @@ namespace PuppeteerSharp
 
             if (!responseHeaders.ContainsKey("content-length") && response.BodyData != null)
             {
-                responseHeaders["content-length"] = response.BodyData.Length.ToString();
+                responseHeaders["content-length"] = response.BodyData.Length.ToString(CultureInfo.CurrentCulture);
             }
 
             try


### PR DESCRIPTION
* CA1304 on the ruleset file set to Error

* Enabled 1305,1720,1721,1806 Rules

* Update lib/PuppeteerSharp/BrowserFetcher.cs

Removing comment

Co-authored-by: Darío Kondratiuk <dariokondratiuk@gmail.com>

* Suppressed CA1720

* Made DefaultArgs Internal for CA1721

* Supressing CA1720 for String in RmeoteObjectType

* Ruleset file reverted and added new changes

Co-authored-by: Venkatesh Prasad <Venkatesh.Prasad@philips.com>
Co-authored-by: Darío Kondratiuk <dariokondratiuk@gmail.com>